### PR TITLE
Add theme toggle to chat header

### DIFF
--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import Link from "next/link";
+import { Moon, Sun } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { memo } from "react";
+import { useTheme } from "next-themes";
+import { memo, useEffect, useMemo, useState } from "react";
 import { useWindowSize } from "usehooks-ts";
 import { SidebarToggle } from "@/components/sidebar-toggle";
 import { Button } from "@/components/ui/button";
-import { PlusIcon, VercelIcon } from "./icons";
+import { cn } from "@/lib/utils";
+import { PlusIcon } from "./icons";
 import { useSidebar } from "./ui/sidebar";
 import { VisibilitySelector, type VisibilityType } from "./visibility-selector";
 
@@ -21,14 +23,53 @@ function PureChatHeader({
 }) {
   const router = useRouter();
   const { open } = useSidebar();
+  const { resolvedTheme, setTheme } = useTheme();
 
   const { width: windowWidth } = useWindowSize();
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const shouldShowNewChat = !open || windowWidth < 768;
+
+  const themeToggleLabel = useMemo(() => {
+    if (!isMounted) {
+      return "Toggle theme";
+    }
+
+    return resolvedTheme === "dark"
+      ? "Switch to light mode"
+      : "Switch to dark mode";
+  }, [isMounted, resolvedTheme]);
+
+  const themeToggleIcon = useMemo(() => {
+    if (!isMounted) {
+      return <Moon className="size-4" />;
+    }
+
+    return resolvedTheme === "dark" ? (
+      <Sun className="size-4" />
+    ) : (
+      <Moon className="size-4" />
+    );
+  }, [isMounted, resolvedTheme]);
+
+  const handleThemeToggle = () => {
+    if (!isMounted) {
+      return;
+    }
+
+    const nextTheme = resolvedTheme === "dark" ? "light" : "dark";
+    setTheme(nextTheme);
+  };
 
   return (
     <header className="sticky top-0 flex items-center gap-2 bg-background px-2 py-1.5 md:px-2">
       <SidebarToggle />
 
-      {(!open || windowWidth < 768) && (
+      {shouldShowNewChat && (
         <Button
           className="order-2 ml-auto h-8 px-2 md:order-1 md:ml-0 md:h-fit md:px-2"
           onClick={() => {
@@ -51,17 +92,18 @@ function PureChatHeader({
       )}
 
       <Button
-        asChild
-        className="order-3 hidden bg-zinc-900 px-2 text-zinc-50 hover:bg-zinc-800 md:ml-auto md:flex md:h-fit dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        aria-label={themeToggleLabel}
+        className={cn(
+          "order-4 h-8 w-8 md:h-9 md:w-9",
+          shouldShowNewChat ? "ml-1" : "ml-auto"
+        )}
+        disabled={!isMounted}
+        onClick={handleThemeToggle}
+        size="icon"
+        variant="ghost"
       >
-        <Link
-          href={"https://vercel.com/templates/next.js/nextjs-ai-chatbot"}
-          rel="noreferrer"
-          target="_noblank"
-        >
-          <VercelIcon size={16} />
-          Deploy with Vercel
-        </Link>
+        {themeToggleIcon}
+        <span className="sr-only">{themeToggleLabel}</span>
       </Button>
     </header>
   );

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -50,10 +50,6 @@ function PureChatHeader({
   }, [isMounted, resolvedTheme]);
 
   const handleThemeToggle = () => {
-    if (!isMounted) {
-      return;
-    }
-
     const nextTheme = resolvedTheme === "dark" ? "light" : "dark";
     setTheme(nextTheme);
   };

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -34,16 +34,9 @@ function PureChatHeader({
 
   const shouldShowNewChat = !open || windowWidth < 768;
 
-  const themeToggleLabel = useMemo(() => {
-    if (!isMounted) {
-      return "Toggle theme";
-    }
-
-    return resolvedTheme === "dark"
-      ? "Switch to light mode"
-      : "Switch to dark mode";
-  }, [isMounted, resolvedTheme]);
-
+  const themeToggleLabel = !isMounted
+    ? "Toggle theme"
+    : (resolvedTheme === "dark" ? "Switch to light mode" : "Switch to dark mode");
   const themeToggleIcon = useMemo(() => {
     if (!isMounted) {
       return <Moon className="size-4" />;


### PR DESCRIPTION
## Summary
- replace the deploy call-to-action in the chat header with a light/dark mode toggle
- add client-side theme state handling to avoid hydration flicker and respect sidebar layout changes

## Testing
- pnpm lint *(fails: repository has pre-existing formatting violations outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc2b3ba208328ae7e36681000a3c3