### PR TITLE
Adopt Vercel AI gateway integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ AUTH_SECRET=****
 # For Vercel deployments, OIDC tokens are used automatically
 AI_GATEWAY_API_KEY=****
 
+# Optional: override the Gateway base URL when using a custom domain
+# AI_GATEWAY_URL=https://your-custom-gateway.vercel.sh/v1/ai
+
 
 # Instructions to create a Vercel Blob Store here: https://vercel.com/docs/storage/vercel-blob
 BLOB_READ_WRITE_TOKEN=****

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Copy `.env.example` to `.env.local` and configure:
 - `POSTGRES_URL`: PostgreSQL connection string
 - `BLOB_READ_WRITE_TOKEN`: Vercel Blob storage token
 - `AI_GATEWAY_API_KEY`: Required for non-Vercel deployments (OIDC used on Vercel)
+- `AI_GATEWAY_URL`: Optional, override when using a custom Gateway domain
 - `REDIS_URL`: Optional, enables resumable streams
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -49,11 +49,16 @@ pnpm install
 
 # 3. Configure environment
 cp .env.example .env.local
-# Fill in required keys: Postgres, Clerk, Vercel
+# Fill in required keys: Postgres, Clerk, Vercel AI Gateway
 
 # Example Clerk keys
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your_clerk_publishable_key
 CLERK_SECRET_KEY=your_clerk_secret_key
+
+# Vercel AI Gateway (local development uses the API key)
+AI_GATEWAY_API_KEY=your_gateway_key
+# Optional: custom domain for the gateway (defaults to Vercel managed URL)
+# AI_GATEWAY_URL=https://your-custom-gateway.vercel.sh/v1/ai
 
 # 4. Run locally
 pnpm dev

--- a/demo/gateway.ts
+++ b/demo/gateway.ts
@@ -1,10 +1,16 @@
-import { streamText } from 'ai';
-import 'dotenv/config';
+import { createGateway } from "@ai-sdk/gateway";
+import { streamText } from "ai";
+import "dotenv/config";
+
+const gateway = createGateway({
+  apiKey: process.env.AI_GATEWAY_API_KEY,
+  baseURL: process.env.AI_GATEWAY_URL,
+});
 
 async function main() {
   const result = streamText({
-    model: 'openai/gpt-4.1',
-    prompt: 'Invent a new holiday and describe its traditions.',
+    model: gateway.languageModel("openai/gpt-4.1"),
+    prompt: "Invent a new holiday and describe its traditions.",
   });
 
   for await (const textPart of result.textStream) {
@@ -12,8 +18,8 @@ async function main() {
   }
 
   console.log();
-  console.log('Token usage:', await result.usage);
-  console.log('Finish reason:', await result.finishReason);
+  console.log("Token usage:", await result.usage);
+  console.log("Finish reason:", await result.finishReason);
 }
 
 main().catch(console.error);

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@ai-sdk/gateway": "^1.0.32",
     "@types/node": "^24.6.1",
     "ai": "^5.0.59",
     "dotenv": "^17.2.3",

--- a/demo/pnpm-lock.yaml
+++ b/demo/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/gateway':
+        specifier: ^1.0.32
+        version: 1.0.32(zod@4.1.11)
       '@types/node':
         specifier: ^24.6.1
         version: 24.6.1

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -1,10 +1,15 @@
-import { gateway } from "@ai-sdk/gateway";
+import { createGateway } from "@ai-sdk/gateway";
 import {
   customProvider,
   extractReasoningMiddleware,
   wrapLanguageModel,
 } from "ai";
 import { isTestEnvironment } from "../constants";
+
+const vercelGateway = createGateway({
+  apiKey: process.env.AI_GATEWAY_API_KEY,
+  baseURL: process.env.AI_GATEWAY_URL,
+});
 
 export const myProvider = isTestEnvironment
   ? (() => {
@@ -25,12 +30,12 @@ export const myProvider = isTestEnvironment
     })()
   : customProvider({
       languageModels: {
-        "chat-model": gateway.languageModel("xai/grok-2-vision-1212"),
+        "chat-model": vercelGateway.languageModel("xai/grok-2-vision-1212"),
         "chat-model-reasoning": wrapLanguageModel({
-          model: gateway.languageModel("xai/grok-3-mini"),
+          model: vercelGateway.languageModel("xai/grok-3-mini"),
           middleware: extractReasoningMiddleware({ tagName: "think" }),
         }),
-        "title-model": gateway.languageModel("xai/grok-2-1212"),
-        "artifact-model": gateway.languageModel("xai/grok-2-1212"),
+        "title-model": vercelGateway.languageModel("xai/grok-2-1212"),
+        "artifact-model": vercelGateway.languageModel("xai/grok-2-1212"),
       },
     });


### PR DESCRIPTION
## Summary
- configure the shared AI provider to instantiate the Vercel AI Gateway client with optional base URL overrides
- document gateway environment setup in the README, CLAUDE guide, and the dedicated gateway guide
- update the demo script and dependencies to route through the gateway when streaming

## Testing
- ❌ `pnpm lint` *(fails due to existing formatting issues reported in app/layout.tsx and lib/editor/suggestions.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc26b6b28832892fbb89192403acf